### PR TITLE
Add text encoding.

### DIFF
--- a/UI/Components/AutoStreamMarkerComponent.cs
+++ b/UI/Components/AutoStreamMarkerComponent.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Xml;
 using System.Net;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Collections;
 using System.Collections.Specialized;
@@ -54,6 +55,7 @@ namespace LiveSplit.UI.Components
             Web = new WebClient();
             Web.Headers.Add("Client-ID", Settings.TwitchClientID);
             Web.Headers.Add("Accept", "application/vnd.twitchtv.v5+json");
+            Web.Encoding = Encoding.UTF8;
         }
 
         public override void Dispose()

--- a/UI/Components/AutoStreamMarkerSettings.cs
+++ b/UI/Components/AutoStreamMarkerSettings.cs
@@ -33,6 +33,7 @@ namespace LiveSplit.UI.Components
             Web = new WebClient();
             Web.Headers.Add("Client-ID", TwitchClientID);
             Web.Headers.Add("Accept", "application/vnd.twitchtv.v5+json");
+            Web.Encoding = Encoding.UTF8;
 
             chkMarkEverySplit.DataBindings.Add("Checked", this, "MarkEverySplit");
             chkMarkResets.DataBindings.Add("Checked", this, "MarkResets");


### PR DESCRIPTION
Regarding the issue where pressing the Connect button failed to establish a connection, I determined that when Twitch's response contained a Unicode string, an exception occurred during JSON.FromString(), causing subsequent processing to fail. #2 

I added encoding specification when creating the WebClient Web object.